### PR TITLE
Include rspec integration if rspec is defined

### DIFF
--- a/lib/virtus/matchers.rb
+++ b/lib/virtus/matchers.rb
@@ -3,3 +3,4 @@
 require 'virtus/matchers/version'
 require 'virtus/matchers/be_value_object_matcher'
 require 'virtus/matchers/have_attribute_matcher'
+require 'virtus/matchers/integrations'

--- a/lib/virtus/matchers/integrations.rb
+++ b/lib/virtus/matchers/integrations.rb
@@ -1,0 +1,5 @@
+if defined?(RSpec)
+  RSpec.configure do |config|
+    config.include Virtus::Matchers
+  end
+end


### PR DESCRIPTION
Allow users of the gem to use the matchers directly in their specs without having to `include` manually.
