### PR TITLE
Add matcher for default values

### DIFF
--- a/lib/virtus/matchers.rb
+++ b/lib/virtus/matchers.rb
@@ -3,3 +3,4 @@
 require 'virtus/matchers/version'
 require 'virtus/matchers/be_value_object_matcher'
 require 'virtus/matchers/have_attribute_matcher'
+require 'virtus/matchers/integrations'

--- a/lib/virtus/matchers/have_attribute_matcher.rb
+++ b/lib/virtus/matchers/have_attribute_matcher.rb
@@ -13,6 +13,11 @@ module Virtus
         self
       end
 
+      def with_default(expected_default)
+        @expected_default = expected_default
+        self
+      end
+
       def matches?(klass)
         @klass = klass
         @attribute = @klass.attribute_set[@name]
@@ -23,13 +28,14 @@ module Virtus
             @attribute.options[:member_type].primitive == @type.first
         end
 
-        valid_type && valid_coercer
+        valid_type && valid_coercer && valid_default
       end
 
       def description
         type = @type.class == Array ? "Array#{@type}" : @type
         str = "have attribute #{@name}"
         str += " of type #{type}#{coercer_description}" unless @type.nil?
+        str += " with default \"#{@expected_default}\"" if @expected_default
         str
       end
 
@@ -38,6 +44,11 @@ module Virtus
       end
 
       private
+
+      def valid_default
+        @expected_default.nil? || @attribute.default_value.value == @expected_default
+      end
+
       def valid_type
         @type.nil? || @attribute.primitive == @type
       end

--- a/lib/virtus/matchers/integrations.rb
+++ b/lib/virtus/matchers/integrations.rb
@@ -1,0 +1,5 @@
+if defined?(RSpec)
+  RSpec.configure do |config|
+    config.include Virtus::Matchers
+  end
+end

--- a/spec/virtus/matchers/have_attribute_matcher_spec.rb
+++ b/spec/virtus/matchers/have_attribute_matcher_spec.rb
@@ -11,6 +11,8 @@ describe Virtus::Matchers::HaveAttributeMatcher do
     attribute :bar, Array[String]
     attribute :baz, Array
     attribute :lol, DateTime, coercer: FakeCoercer
+    attribute :hello, String, default: "Hello"
+    attribute :hi_no_default, String
   end
 
   context 'when attribute is defined', 'with no type' do
@@ -127,6 +129,40 @@ describe Virtus::Matchers::HaveAttributeMatcher do
     it 'should have a failure message' do
       matcher.matches?(Example)
       matcher.failure_message.should == "expected #{Example} to have attribute baz of type String"
+    end
+  end
+
+  context 'checking for default' do
+    context "when default matches expected default" do
+      let(:matcher) { described_class.new(:hello, String).with_default("Hello") }
+
+      it 'matches' do
+        expect(matcher.matches?(Example)).to be true
+      end
+    end
+
+    context "when default does not match the expected default" do
+      let(:matcher) { described_class.new(:hello, String).with_default("Hala") }
+
+      it 'does not match' do
+        expect(matcher.matches?(Example)).to be false
+      end
+    end
+
+    context "there is an expected default, but none is set" do
+      let(:matcher) do
+        described_class.new(:hi_no_default, String).with_default("Hello")
+      end
+
+      it 'does not match' do
+        expect(matcher.matches?(Example)).to be false
+      end
+    end
+
+    it 'has a description' do
+      matcher = described_class.new(:hello, String).with_default("Hello")
+      matcher.matches?(Example)
+      expect(matcher.description).to eq 'have attribute hello of type String with default "Hello"'
     end
   end
 end

--- a/virtus-matchers.gemspec
+++ b/virtus-matchers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', "~> 2.14"
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'rb-fsevent'
 end


### PR DESCRIPTION
Requires https://github.com/tmattia/virtus-matchers/pull/1 to be merged in first.
### Usage:

Class:

``` ruby
class Example
  include Virtus.model
  attribute :hello, String, default: "Hello"
end
```

Spec:

``` ruby
describe Example do
  it { is_expected.to have_attribute(:hello, String).with_default("Hello") }
end
```
